### PR TITLE
2026.3.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/game-mapping.yml
+++ b/.github/ISSUE_TEMPLATE/game-mapping.yml
@@ -1,0 +1,53 @@
+name: "🎮 Game Mapping Request"
+description: "Report a missing game or a naming mismatch (e.g., Rugby 15, Roblox)."
+title: "[Mapping]: <Game Name>"
+labels: ["enhancement", "game-mapping"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thanks for helping!
+        Please provide the details below so we can update the `mapping.json` file.
+  - type: input
+    id: xbox_name
+    attributes:
+      label: "Xbox Game Name"
+      description: "The exact name shown in Home Assistant."
+      placeholder: "e.g. Rugby 15"
+    validations:
+      required: true
+  - type: input
+    id: ta_name
+    attributes:
+      label: "TrueAchievements Name"
+      description: "The exact name on the TA website or CSV."
+      placeholder: "e.g. RUGBY 15 (Xbox 360)"
+    validations:
+      required: true
+  - type: input
+    id: publisher
+    attributes:
+      label: "Publisher"
+      description: "Check the 'publisher' attribute in your HA sensor."
+      placeholder: "e.g. Bigben Interactive"
+    validations:
+      required: false
+  - type: dropdown
+    id: platform
+    attributes:
+      label: "Platform"
+      description: "Which console version is this?"
+      options:
+        - "Xbox Series X|S"
+        - "Xbox One"
+        - "Xbox 360"
+        - "Windows"
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: "Verification"
+      options:
+        - label: "I have verified the name on TrueAchievements.com"
+          required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 <!--next-version-placeholder-->
 
+## 2026.3.3
+
+- **Improved** Advanced Game Mapping: Added support for combined `Publisher | Platform` keys in `mapping.json`. This resolves conflicts for games with identical names and publishers across different console generations (e.g., Rugby 15 on Xbox 360 vs Xbox One).
+- **Refined** Coordinator Logic: Updated the name resolution engine to prioritize specific platform-based matches before falling back to general publisher or title matches.
+- **Added** Community Support: Introduced a new GitHub Issue Template for Game Mapping. Users can now easily report naming mismatches with specific fields for Publisher and Platform.
+- **Fixed** Documentation: Updated README with a dedicated FAQ section for "Offline" status and naming troubleshooting.
+
 ## 2026.3.2
 
 - **Breaking Change** Minimum Requirement: Now requires **Home Assistant 2026.4.0b1** or newer. This is mandatory to support the new `platform` attribute and updated metadata standards from the official Xbox integration.

--- a/README.md
+++ b/README.md
@@ -126,13 +126,15 @@ To ensure a successful connection, you should copy the full cookie string from y
 
 ### Why is my current game showing "Offline" or missing details?
 
-This usually happens when the name provided by the Xbox integration doesn't perfectly match the name in the TrueAchievements database (e.g., "Roblox - Xbox" vs "ROBLOX").
+This usually happens when the name provided by the **Xbox integration** doesn't perfectly match the name in the **TrueAchievements database** (e.g., `Roblox - Xbox` vs `ROBLOX`).
 
 1. **Check your notifications:** Home Assistant will alert you if a mismatch is detected.
-2. **Report the mismatch:** Open a request on our [Game Mapping Issue](https://github.com/dckiller51/trueachievements/issues/2).
-3. **Include details:** Provide the exact name shown in Home Assistant and the one on TrueAchievements.
+2. **Report the mismatch:** Open a request using our [Game Mapping Form](https://github.com/dckiller51/trueachievements/issues/new?template=game-mapping.yml).
+3. **Provide context:** Some games exist on multiple platforms (Xbox 360, Xbox One, Series X|S). If the name is identical but the stats are wrong, please specify the **Publisher** and **Platform** shown in your sensor attributes.
+4. **Include details:** Provide the exact name shown in Home Assistant and the link to the game's page on TrueAchievements.
 
-We regularly update the internal dictionary to fix these naming inconsistencies.
+> [!NOTE]
+> We regularly update the internal dictionary (`mapping.json`) to fix these naming inconsistencies and handle cross-generation title conflicts.
 
 ## Privacy & Security
 

--- a/custom_components/trueachievements/const.py
+++ b/custom_components/trueachievements/const.py
@@ -2,11 +2,11 @@
 
 NAME = "TrueAchievements"
 DOMAIN = "trueachievements"
-VERSION = "2026.3.2"
+VERSION = "2026.3.3"
 
 # GitHub URLs
 ISSUE_URL = "https://github.com/dckiller51/trueachievements/issues"
-ISSUE_URL_MAPPING = "https://github.com/dckiller51/trueachievements/issues/2"
+ISSUE_URL_MAPPING = "https://github.com/dckiller51/trueachievements/issues/new?template=game-mapping.yml"
 
 # Configuration keys
 CONF_AUTH_STATUS = "auth_status"

--- a/custom_components/trueachievements/coordinator.py
+++ b/custom_components/trueachievements/coordinator.py
@@ -224,7 +224,7 @@ class TrueAchievementsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         current_plat = str(safe_info.get("platform") or "").lower()
         current_pub = str(safe_info.get("publisher") or "Unknown").lower().strip()
 
-        lookup_name = self._resolve_mapped_name(current_name, current_pub)
+        lookup_name = self._resolve_mapped_name(current_name, current_pub, current_plat)
         target_name_low = lookup_name.lower().strip()
 
         stats = {
@@ -308,16 +308,25 @@ class TrueAchievementsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "current_game_details": current_game_stats,
         }
 
-    def _resolve_mapped_name(self, name: str, publisher: str) -> str:
-        """Resolve game name from mapping file."""
+    def _resolve_mapped_name(self, name: str, publisher: str, platform: str) -> str:
+        """Resolve game name using Publisher and Platform if necessary."""
         name_low = name.lower().strip()
+        pub_low = publisher.lower().strip()
+        plat_low = platform.lower().strip()
+
         if name_low in self.game_mapping:
             mapping_val = self.game_mapping[name_low]
             if isinstance(mapping_val, dict):
-                lower_pub_map = {
-                    str(k).lower().strip(): v for k, v in mapping_val.items()
-                }
-                return str(lower_pub_map.get(publisher, name))
+                lower_map = {str(k).lower().strip(): v for k, v in mapping_val.items()}
+                combo_key = f"{pub_low}|{plat_low}"
+                if combo_key in lower_map:
+                    return str(lower_map[combo_key])
+                if pub_low in lower_map:
+                    return str(lower_map[pub_low])
+                if plat_low in lower_map:
+                    return str(lower_map[plat_low])
+
+                return str(lower_map.get("unknown", name))
             return str(mapping_val)
         return name
 

--- a/custom_components/trueachievements/manifest.json
+++ b/custom_components/trueachievements/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/dckiller51/trueachievements/issues",
   "requirements": [],
-  "version": "2026.3.2"
+  "version": "2026.3.3"
 }

--- a/custom_components/trueachievements/mapping.json
+++ b/custom_components/trueachievements/mapping.json
@@ -61,8 +61,9 @@
   "PAW Patrol™ Rescue Wheels™: Championship": "PAW Patrol Rescue Wheels: Championship",
   "Roblox - Xbox": "ROBLOX",
   "Rugby 15": {
-    "Bigben Interactive": "RUGBY 15 (EU)",
-    "Maximum Entertainment": "RUGBY 15"
+    "bigben interactive|xbox 360": "RUGBY 15 (Xbox 360)",
+    "bigben interactive|xbox one": "RUGBY 15 (EU)",
+    "maximum entertainment": "RUGBY 15"
   },
   "TCG Card Shop Simulator (Game Preview)": "TCG Card Shop Simulator",
   "The Talos Principle 2": "The Talos Principle II",


### PR DESCRIPTION
## 2026.3.3

- **Improved** Advanced Game Mapping: Added support for combined `Publisher | Platform` keys in `mapping.json`. This resolves conflicts for games with identical names and publishers across different console generations (e.g., Rugby 15 on Xbox 360 vs Xbox One).
- **Refined** Coordinator Logic: Updated the name resolution engine to prioritize specific platform-based matches before falling back to general publisher or title matches.
- **Added** Community Support: Introduced a new GitHub Issue Template for Game Mapping. Users can now easily report naming mismatches with specific fields for Publisher and Platform.
- **Fixed** Documentation: Updated README with a dedicated FAQ section for "Offline" status and naming troubleshooting.