### PR TITLE
feat(notifications): add toggles and translations for game mapping/auth alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 <!--next-version-placeholder-->
 
+## 2026.6.0
+
+- **Added** Notification Toggles: New options `notify_mapping` and `notify_auth_error` let you disable the persistent notifications for unmatched games and expired authentication independently, directly from the integration's Options flow. Resolves #27.
+- **Added** Notification Translations: Persistent notification titles and messages (game mapping alerts, auth errors) are now translatable via the `common` section of the language files, with automatic fallback to English if a translation is missing or incomplete.
+- **Improved** Game Matching: Updated `mapping.json` with new titles and platform fixes for better accuracy.
+
 ## 2026.4.0
 
 - **Improved** Game Matching: Updated `mapping.json` with new titles and platform fixes for better accuracy.

--- a/custom_components/trueachievements/config_flow.py
+++ b/custom_components/trueachievements/config_flow.py
@@ -20,8 +20,12 @@ from .const import (
     CONF_GAMERTAG,
     CONF_GAMERTOKEN,
     CONF_GAMES_FILE,
+    CONF_NOTIFY_AUTH_ERROR,
+    CONF_NOTIFY_MAPPING,
     CONF_NOW_PLAYING_ENTITY,
     DEFAULT_GAMES_FILE,
+    DEFAULT_NOTIFY_AUTH_ERROR,
+    DEFAULT_NOTIFY_MAPPING,
     DOMAIN,
 )
 
@@ -56,6 +60,12 @@ class TrueAchievementsConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                     vol.Optional(CONF_EXCLUDED_APPS, default=""): str,
                     vol.Required(CONF_GAMES_FILE, default=DEFAULT_GAMES_FILE): str,
+                    vol.Optional(
+                        CONF_NOTIFY_MAPPING, default=DEFAULT_NOTIFY_MAPPING
+                    ): bool,
+                    vol.Optional(
+                        CONF_NOTIFY_AUTH_ERROR, default=DEFAULT_NOTIFY_AUTH_ERROR
+                    ): bool,
                 }
             ),
         )
@@ -89,6 +99,16 @@ class TrueAchievementsOptionsFlowHandler(OptionsFlow):
         current_now_playing = self.config_entry.options.get(
             CONF_NOW_PLAYING_ENTITY, self.config_entry.data.get(CONF_NOW_PLAYING_ENTITY)
         )
+        notify_mapping = self.config_entry.options.get(
+            CONF_NOTIFY_MAPPING,
+            self.config_entry.data.get(CONF_NOTIFY_MAPPING, DEFAULT_NOTIFY_MAPPING),
+        )
+        notify_auth_error = self.config_entry.options.get(
+            CONF_NOTIFY_AUTH_ERROR,
+            self.config_entry.data.get(
+                CONF_NOTIFY_AUTH_ERROR, DEFAULT_NOTIFY_AUTH_ERROR
+            ),
+        )
 
         return self.async_show_form(
             step_id="init",
@@ -103,6 +123,10 @@ class TrueAchievementsOptionsFlowHandler(OptionsFlow):
                         )
                     ),
                     vol.Optional(CONF_EXCLUDED_APPS, default=excluded): str,
+                    vol.Optional(CONF_NOTIFY_MAPPING, default=notify_mapping): bool,
+                    vol.Optional(
+                        CONF_NOTIFY_AUTH_ERROR, default=notify_auth_error
+                    ): bool,
                 }
             ),
         )

--- a/custom_components/trueachievements/const.py
+++ b/custom_components/trueachievements/const.py
@@ -2,7 +2,7 @@
 
 NAME = "TrueAchievements"
 DOMAIN = "trueachievements"
-VERSION = "2026.4.0"
+VERSION = "2026.6.0"
 
 # GitHub URLs
 ISSUE_URL = "https://github.com/dckiller51/trueachievements/issues"
@@ -16,6 +16,12 @@ CONF_GAMERTOKEN = "gamertoken"
 CONF_NOW_PLAYING_ENTITY = "now_playing_entity"
 CONF_EXCLUDED_APPS = "excluded_apps"
 CONF_GAMES_FILE = "games_file"
+CONF_NOTIFY_MAPPING = "notify_mapping"
+CONF_NOTIFY_AUTH_ERROR = "notify_auth_error"
+
+# Defaults for notification toggles
+DEFAULT_NOTIFY_MAPPING = True
+DEFAULT_NOTIFY_AUTH_ERROR = True
 
 # Default file paths
 # Note: These are usually stored within the /config/ folder of Home Assistant

--- a/custom_components/trueachievements/coordinator.py
+++ b/custom_components/trueachievements/coordinator.py
@@ -28,8 +28,12 @@ from .const import (
     CONF_GAMERTAG,
     CONF_GAMERTOKEN,
     CONF_GAMES_FILE,
+    CONF_NOTIFY_AUTH_ERROR,
+    CONF_NOTIFY_MAPPING,
     CONF_NOW_PLAYING_ENTITY,
     DEFAULT_GAMES_FILE,
+    DEFAULT_NOTIFY_AUTH_ERROR,
+    DEFAULT_NOTIFY_MAPPING,
     DOMAIN,
     ISSUE_URL_MAPPING,
     URL_EXPORT_COLLECTION,
@@ -63,8 +67,12 @@ class TrueAchievementsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.gamer_token: str = ""
         self.games_file: Path = Path("")
         self.excluded_apps: list[str] = []
+        self.notify_mapping: bool = DEFAULT_NOTIFY_MAPPING
+        self.notify_auth_error: bool = DEFAULT_NOTIFY_AUTH_ERROR
         self.mapping_file: Path = Path(__file__).parent / "mapping.json"
         self.game_mapping: dict[str, Any] = {}
+        self.translations_dir: Path = Path(__file__).parent / "translations"
+        self.notify_translations: dict[str, str] = {}
 
         now_playing_eid: str | None = entry.options.get(
             CONF_NOW_PLAYING_ENTITY, entry.data.get(CONF_NOW_PLAYING_ENTITY)
@@ -91,6 +99,18 @@ class TrueAchievementsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.excluded_apps = [
             app.strip().lower() for app in excluded_raw.split(",") if app.strip()
         ]
+        self.notify_mapping = bool(
+            opts.get(
+                CONF_NOTIFY_MAPPING,
+                dat.get(CONF_NOTIFY_MAPPING, DEFAULT_NOTIFY_MAPPING),
+            )
+        )
+        self.notify_auth_error = bool(
+            opts.get(
+                CONF_NOTIFY_AUTH_ERROR,
+                dat.get(CONF_NOTIFY_AUTH_ERROR, DEFAULT_NOTIFY_AUTH_ERROR),
+            )
+        )
 
     async def _handle_state_change(self, _event: Any) -> None:
         """Trigger a refresh when the Xbox game status changes."""
@@ -101,6 +121,9 @@ class TrueAchievementsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Fetch data from TA with 24h safety lock or use local CSV."""
         self._update_local_config()
         self.game_mapping = await self.hass.async_add_executor_job(self._load_mapping)
+        self.notify_translations = await self.hass.async_add_executor_job(
+            self._load_notify_translations
+        )
 
         now = dt_util.now()
         should_download = True
@@ -168,6 +191,29 @@ class TrueAchievementsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception:  # pylint: disable=broad-exception-caught
             return {}
 
+    def _load_notify_translations(self) -> dict[str, str]:
+        """Load notification strings from the translation files.
+
+        Tries the HA-configured language first, then falls back to English.
+        Strings live under the "common" key so they can be shared with any
+        notification (persistent or mobile), independently of the config_flow
+        and entity translations.
+        """
+        language = self.hass.config.language
+        for lang in (language, "en"):
+            path = self.translations_dir / f"{lang}.json"
+            if not path.exists():
+                continue
+            try:
+                with open(path, encoding="utf-8") as f:
+                    data = json.load(f)
+                common = data.get("common", {})
+                if isinstance(common, dict) and common:
+                    return {str(k): str(v) for k, v in common.items()}
+            except Exception:  # pylint: disable=broad-exception-caught
+                _LOGGER.debug("Failed to load notify translations for lang=%s", lang)
+        return {}
+
     def _write_file(self, content: bytes) -> None:
         """Physically save the CSV file."""
         self.games_file.parent.mkdir(parents=True, exist_ok=True)
@@ -175,13 +221,27 @@ class TrueAchievementsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _send_error_notification(self) -> None:
         """Send a persistent notification for expired credentials."""
+        if not self.notify_auth_error:
+            return
+
+        title = self.notify_translations.get(
+            "auth_error_title", "TrueAchievements: Access Error"
+        )
+        message_tpl = self.notify_translations.get(
+            "auth_error_message", "The cookie for **{gamer_tag}** has expired."
+        )
+        try:
+            message = message_tpl.format(gamer_tag=self.gamer_tag)
+        except Exception:  # pylint: disable=broad-exception-caught
+            message = f"The cookie for **{self.gamer_tag}** has expired."
+
         self.hass.add_job(
             self.hass.services.async_call,
             "persistent_notification",
             "create",
             {
-                "message": f"The cookie for **{self.gamer_tag}** has expired.",
-                "title": "TrueAchievements: Access Error",
+                "message": message,
+                "title": title,
                 "notification_id": "ta_access_error",
             },
         )
@@ -373,6 +433,8 @@ class TrueAchievementsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self, lookup_name: str, match_found: bool, current_name: str, info: dict
     ) -> None:
         """Handle 'Game not found' notifications."""
+        if not self.notify_mapping:
+            return
         if lookup_name and not match_found and lookup_name not in self._notified_games:
             if current_name.lower() not in (
                 "unavailable",
@@ -381,16 +443,35 @@ class TrueAchievementsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "offline_status",
             ):
                 self._notified_games.add(lookup_name)
+
+                title = self.notify_translations.get(
+                    "mapping_title", "TrueAchievements: Action Required"
+                )
+                message_tpl = self.notify_translations.get(
+                    "mapping_message",
+                    "Game **{game}** ({platform}) not matching. "
+                    "Publisher: {publisher}. [Report here]({issue_url})",
+                )
+                try:
+                    message = message_tpl.format(
+                        game=lookup_name,
+                        platform=info.get("platform"),
+                        publisher=info.get("publisher"),
+                        issue_url=ISSUE_URL_MAPPING,
+                    )
+                except Exception:  # pylint: disable=broad-exception-caught
+                    message = (
+                        f"Game **{lookup_name}** ({info.get('platform')}) not matching. "
+                        f"Publisher: {info.get('publisher')}. [Report here]({ISSUE_URL_MAPPING})"
+                    )
+
                 self.hass.add_job(
                     self.hass.services.async_call,
                     "persistent_notification",
                     "create",
                     {
-                        "title": "TrueAchievements: Action Required",
-                        "message": (
-                            f"Game **{lookup_name}** ({info.get('platform')}) not matching. "
-                            f"Publisher: {info.get('publisher')}. [Report here]({ISSUE_URL_MAPPING})"
-                        ),
+                        "title": title,
+                        "message": message,
                         "notification_id": f"ta_fix_{lookup_name.replace(' ', '_')}",
                     },
                 )

--- a/custom_components/trueachievements/manifest.json
+++ b/custom_components/trueachievements/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/dckiller51/trueachievements/issues",
   "requirements": [],
-  "version": "2026.4.0"
+  "version": "2026.6.0"
 }

--- a/custom_components/trueachievements/mapping.json
+++ b/custom_components/trueachievements/mapping.json
@@ -58,6 +58,7 @@
   "Minecraft for Gear VR": "Minecraft (Gear VR)",
   "Minecraft for Kindle Fire": "Minecraft (Kindle Fire)",
   "Minecraft for Nintendo Switch": "Minecraft (Nintendo Switch)",
+  "Minecraft for Windows": "Minecraft (Windows)",
   "MyMaitê (for Windows 10)": "MyMaitê (Windows)",
   "NHL® 94 REWIND": "NHL 94 Rewind",
   "New MONOPOLY®": "New MONOPOLY",

--- a/custom_components/trueachievements/translations/en.json
+++ b/custom_components/trueachievements/translations/en.json
@@ -1,4 +1,10 @@
 {
+  "common": {
+    "auth_error_message": "The cookie for **{gamer_tag}** has expired.",
+    "auth_error_title": "TrueAchievements: Access Error",
+    "mapping_message": "Game **{game}** ({platform}) not matching. Publisher: {publisher}. [Report here]({issue_url})",
+    "mapping_title": "TrueAchievements: Action Required"
+  },
   "config": {
     "abort": {
       "already_configured": "This account is already configured."
@@ -16,6 +22,8 @@
           "gamertag": "Xbox Gamertag",
           "gamertoken": "Session Token (Cookie)",
           "games_file": "CSV File Path",
+          "notify_auth_error": "Notify on authentication error",
+          "notify_mapping": "Notify on unmatched games (mapping)",
           "now_playing_entity": "Xbox Tracked Entity (Now Playing)"
         },
         "description": "Enter your TrueAchievements credentials. You can find your GamerID in your profile URL and your GamerToken in your cookies (TrueGamingIdentity).",
@@ -85,6 +93,8 @@
         "data": {
           "excluded_apps": "Excluded Apps",
           "gamertoken": "Session Token (Cookie)",
+          "notify_auth_error": "Notify on authentication error",
+          "notify_mapping": "Notify on unmatched games (mapping)",
           "now_playing_entity": "Xbox Tracked Entity"
         }
       }

--- a/custom_components/trueachievements/translations/fr.json
+++ b/custom_components/trueachievements/translations/fr.json
@@ -1,4 +1,10 @@
 {
+  "common": {
+    "auth_error_message": "Le cookie pour **{gamer_tag}** a expiré.",
+    "auth_error_title": "TrueAchievements : erreur d'accès",
+    "mapping_message": "Le jeu **{game}** ({platform}) ne correspond à aucune entrée. Éditeur : {publisher}. [Signaler ici]({issue_url})",
+    "mapping_title": "TrueAchievements : action requise"
+  },
   "config": {
     "abort": {
       "already_configured": "Ce compte est déjà configuré."
@@ -16,6 +22,8 @@
           "gamertag": "GamerTag Xbox",
           "gamertoken": "Token de session (Cookie)",
           "games_file": "Chemin du fichier CSV",
+          "notify_auth_error": "Notifier en cas d'erreur d'authentification",
+          "notify_mapping": "Notifier les jeux non reconnus (mapping)",
           "now_playing_entity": "Entité de suivi Xbox (Now Playing)"
         },
         "description": "Entrez vos identifiants TrueAchievements. Vous pouvez trouver votre GamerID dans l'URL de votre profil et votre GamerToken dans vos cookies (TrueGamingIdentity).",
@@ -85,6 +93,8 @@
         "data": {
           "excluded_apps": "Applications à exclure",
           "gamertoken": "Token de session (Cookie)",
+          "notify_auth_error": "Notifier en cas d'erreur d'authentification",
+          "notify_mapping": "Notifier les jeux non reconnus (mapping)",
           "now_playing_entity": "Entité de suivi Xbox"
         }
       }


### PR DESCRIPTION
## 2026.6.0

- **Added** Notification Toggles: New options `notify_mapping` and `notify_auth_error` let you disable the persistent notifications for unmatched games and expired authentication independently, directly from the integration's Options flow. Resolves #27.
- **Added** Notification Translations: Persistent notification titles and messages (game mapping alerts, auth errors) are now translatable via the `common` section of the language files, with automatic fallback to English if a translation is missing or incomplete.
- **Improved** Game Matching: Updated `mapping.json` with new titles and platform fixes for better accuracy.